### PR TITLE
fix scheme fixer for http: urls

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const transport = require('git-transport-protocol');
 
 module.exports = input => new Promise((resolve, reject) => {
 	// Fix schemeless urls
-	input = input.replace(/^(?!(?:https|git):\/\/)/, 'https://');
+	input = input.replace(/^(?!(?:https?|git):\/\/)/, 'https://');
 
 	const tcp = net.connect({
 		host: url.parse(input).host,


### PR DESCRIPTION
Before this commit you'd get `https://http://....`

@sindresorhus I'm not 100% what was intended in that bit of code, but it would probably better to swap to https://www.npmjs.com/package/hosted-git-info ... maybe necessitating a major version.